### PR TITLE
Added html text option on post action render

### DIFF
--- a/packages/webpage-client/src/bonde-webpage/plugins/Pressure/Email/index.tsx
+++ b/packages/webpage-client/src/bonde-webpage/plugins/Pressure/Email/index.tsx
@@ -3,7 +3,7 @@ import React, { useReducer } from 'react';
 import { Translate } from '../../../components/MobilizationClass';
 import { Count, Form, Targets } from '../components';
 import { GroupTarget } from '../components/Targets';
-import { Header } from '../styles';
+import { Header, Container } from '../styles';
 import { getTargetList } from '../utils';
 import EmailFields from './EmailFields';
 
@@ -30,6 +30,7 @@ type Props = {
       targets: string;
       finish_message_type?: string;
       finish_message?: Record<any, any>;
+      finish_message_html_text?: string;
       finish_message_background?: string;
       count_text?: string;
       show_city?: string;
@@ -161,7 +162,7 @@ export const EmailPressure = ({
             });
         }
       };
-
+  
   if (state.data) {
     const {
       FinishCustomMessage: {
@@ -174,13 +175,22 @@ export const EmailPressure = ({
       },
     } = overrides;
 
-    return finishMessageType === 'custom' ? (
-      <FinishCustomMessage
-        mobilization={mobilization}
-        widget={widget}
-        {...customProps}
-      />
-    ) : (
+    if (finishMessageType === 'html') {
+      return <Container dangerouslySetInnerHTML={{__html:widget.settings.finish_message_html_text || ''}} />;
+    }
+  
+    if (finishMessageType === 'custom') {
+      return (
+        <FinishCustomMessage
+          mobilization={mobilization}
+          widget={widget}
+          {...customProps}
+        />
+      );
+    }
+  
+    // Fallback para o tipo "share" ou qualquer outro valor não tratado
+    return (
       <FinishDefaultMessage
         mobilization={mobilization}
         widget={widget}

--- a/packages/webpage-client/src/bonde-webpage/plugins/Pressure/styles.ts
+++ b/packages/webpage-client/src/bonde-webpage/plugins/Pressure/styles.ts
@@ -17,3 +17,12 @@ export const Header = styled.h2<HeaderProps>`
   font-weight: 400;
   text-align: center;
 `;
+
+export const Container = styled.div`
+  background-color: white;
+  padding: 16px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  max-width: 100%;
+  overflow: auto;
+`;


### PR DESCRIPTION
## Contexto
Esse Pull Request inclui uma opção de renderização de mensagem de pós ação utilizando texto HTML.

## Checklist
- [x] Garantir que tenha agora mais um tipo de mensagem de pós ação (finish message type: html). Sendo que para novas campanhas a opção custom seria desativada, porém mantida para as que já foram criadas com o tipo custom.

## Issues linkadas
- [x] [Edição da mensagem de Pós Ação da Widget de Pressão](https://app.asana.com/1/1105567501435500/project/1161468210277385/task/1209333414406295)

## Screenshots
<img width="1413" alt="Captura de Tela 2025-03-11 às 15 15 25" src="https://github.com/user-attachments/assets/d7c24c27-6912-4607-9efa-1e13f028d83c" />
