### PR TITLE
feat: adjust widget position

### DIFF
--- a/packages/webpage-client/src/bonde-webpage/plugins/Form/index.tsx
+++ b/packages/webpage-client/src/bonde-webpage/plugins/Form/index.tsx
@@ -133,7 +133,7 @@ const FormPlugin = (props: Props) => {
 
  useEffect(() => {
     if(status === 'fulfilled' && messageRef?.current){
-      messageRef?.current?.scrollIntoView({ 
+      (messageRef?.current as any).scrollIntoView({ 
         behavior: 'smooth', 
         block: 'start' 
       });

--- a/packages/webpage-client/src/bonde-webpage/plugins/Form/index.tsx
+++ b/packages/webpage-client/src/bonde-webpage/plugins/Form/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 
 // import { intlShape } from 'react-intl'
 import styled from '@emotion/styled';
@@ -128,6 +128,17 @@ const FormPlugin = (props: Props) => {
   const [errors, setErrors] = useState<Array<string>>([]);
   const [values, setValues] = useState<Record<string, string>>({});
   const [count, setCount] = useState<number>(widget.form_entries_count || 0);
+  const messageRef = useRef(null);
+  
+
+ useEffect(() => {
+    if(status === 'fulfilled' && messageRef?.current){
+      messageRef?.current?.scrollIntoView({ 
+        behavior: 'smooth', 
+        block: 'start' 
+      });
+    }
+  }, [status]);
 
   const handleSubmit = (t: any) => async (e: any) => {
     e.preventDefault();
@@ -204,7 +215,9 @@ const FormPlugin = (props: Props) => {
   return (
     <div id={`widget-${widget.id}`} className={`widget ${headerFont}-header`}>
       {status === 'fulfilled' ? (
-        <ShareButtons {...props} />
+        <div ref={messageRef}>
+          <ShareButtons {...props} />
+        </div>
       ) : (
         renderForm(props, errors)
       )}

--- a/packages/webpage-client/src/bonde-webpage/plugins/Pressure/Email/index.tsx
+++ b/packages/webpage-client/src/bonde-webpage/plugins/Pressure/Email/index.tsx
@@ -100,7 +100,7 @@ export const EmailPressure = ({
 
   useEffect(() => {
     if(state.data && messageRef?.current){
-      messageRef?.current?.scrollIntoView({ 
+      (messageRef?.current as any).scrollIntoView({ 
         behavior: 'smooth', 
         block: 'start' 
       });

--- a/packages/webpage-client/src/bonde-webpage/plugins/Pressure/Email/index.tsx
+++ b/packages/webpage-client/src/bonde-webpage/plugins/Pressure/Email/index.tsx
@@ -1,4 +1,4 @@
-import React, { useReducer } from 'react';
+import React, { useReducer, useRef, useEffect } from 'react';
 
 import { Translate } from '../../../components/MobilizationClass';
 import { Count, Form, Targets } from '../components';
@@ -96,6 +96,16 @@ export const EmailPressure = ({
   overrides,
 }: Props): any => {
   const [state, dispatch] = useReducer(reducer, initialState);
+  const messageRef = useRef(null);
+
+  useEffect(() => {
+    if(state.data && messageRef?.current){
+      messageRef?.current?.scrollIntoView({ 
+        behavior: 'smooth', 
+        block: 'start' 
+      });
+    }
+  }, [state.data]);
 
   const {
     main_color: mainColor,
@@ -181,26 +191,30 @@ export const EmailPressure = ({
       const values = state.data.form_data
       const content = widget.settings.finish_message_html_text?.replace(/{{(.*?)}}/g, (_, chave) => values[chave] || `{{${chave}}}`)
       
-      return <Container dangerouslySetInnerHTML={{__html: content || ''}} />;
+      return (<div ref={messageRef}><Container dangerouslySetInnerHTML={{__html: content || ''}} /></div>);
     }
   
     if (finishMessageType === 'custom') {
       return (
-        <FinishCustomMessage
-          mobilization={mobilization}
-          widget={widget}
-          {...customProps}
-        />
+        <div ref={messageRef}>
+          <FinishCustomMessage
+            mobilization={mobilization}
+            widget={widget}
+            {...customProps}
+          />
+        </div>
       );
     }
   
     // Fallback para o tipo "share" ou qualquer outro valor não tratado
     return (
-      <FinishDefaultMessage
-        mobilization={mobilization}
-        widget={widget}
-        {...defaultProps}
-      />
+      <div ref={messageRef}>
+        <FinishDefaultMessage
+          mobilization={mobilization}
+          widget={widget}
+          {...defaultProps}
+        />
+      </div>
     );
   }
 


### PR DESCRIPTION
<!-- IMPORTANTE: Por favor confira o arquivo CONTRIBUTING.md para ver o guia de contribuição detalhado e remova os itens que não estiver usando. -->

## Contexto
<!-- Qual problema está tentando resolver? -->
Parceiros pediram pra que após o preenchimento do formulário, os botões de pós ação apareçam sem precisar rolar a tela pra cima no celular - ou seja, voltar pro topo do bloco automaticamente.

## Checklist
- [x] Ajustar posicionamento widget após submissão do formulário
<!-- Descreva as principais alterações que este PR faz. -->

## Issues linkadas
- [[BONDE] Melhoria de UI/UX ao submeter formulário](https://app.asana.com/1/1105567501435500/project/1211245962542878/task/1211592753398472?focus=true)
<!-- Adicione as respectivas issues linkadas a este PR. -->

## Screenshots
<!-- Adicione algumas imagens para haver um preview da sua tarefa, para ajudar desenvolvedores e designers a entender facilmente no que você está trabalhando. -->

### Preview:
<img width="634" height="792" alt="Captura de tela de 2025-10-14 16-00-33" src="https://github.com/user-attachments/assets/4eccd9c9-36da-4531-be58-e6cf606e627a" />


## Como testar?
<!-- Adicione algumas instruções de como os reviewers podem testar esse PR. -->

**Simulando comportamento em dispositivos móveis**:
Inspecione a página e submeta o formulário na dimensão de dispositivos móveis. Visto que esse comportamento de não voltar ao topo do widget estava ocorrendo em celulares.